### PR TITLE
Change aws basic credential provider to aws credential provider.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@ Run in port 8080:
 ```bash
 $ docker run -p8080:8080 onlinefilesystem:latest     
 ```
+
+# Set up AWS Credentials
+Set up environment variables:
+```bash
+$ export AWS_ACCESS_KEY_I=<aws access key>
+$ export AWS_SECRET_ACCESS_KEY=<aws secret key>
+```
+Set up in start up file for future use.
+
 ## DEPENDENCY
 ### Run Mysql using AWS RDS
 Add inbound rule with your machine IP on the RDS security page.
 - DB Username: admin
 - DB Password: admin12345
-

--- a/src/main/java/com/onlineFileSystem/springboot/configurations/AWSConfig.java
+++ b/src/main/java/com/onlineFileSystem/springboot/configurations/AWSConfig.java
@@ -2,15 +2,13 @@ package com.onlineFileSystem.springboot.configurations;
 
 import org.springframework.beans.factory.annotation.Configurable;
 
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 
 @Configurable
 public class AWSConfig {
 
-    public AwsCredentials credentials() {
-        AwsCredentials credentials = 
-            AwsBasicCredentials.create("", "");
-        return credentials;
+    public AwsCredentialsProvider credentials() {
+        return DefaultCredentialsProvider.builder().build();
     }
 }

--- a/src/main/java/com/onlineFileSystem/springboot/configurations/S3Config.java
+++ b/src/main/java/com/onlineFileSystem/springboot/configurations/S3Config.java
@@ -2,7 +2,6 @@ package com.onlineFileSystem.springboot.configurations;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -12,10 +11,9 @@ public class S3Config {
 
     @Bean
     public S3Client client() {
-        // TODO: StaticCredentialsProvider should be replaced for security issue
         return S3Client.builder()
             .region(Region.US_EAST_1)
-            .credentialsProvider(StaticCredentialsProvider.create(config.credentials()))
+            .credentialsProvider(config.credentials())
             .build();
     }
 }


### PR DESCRIPTION
1. Change AwsBasicCredentialProvider to AwsCredentialProvider, so that it could load the access key and secret key in env variables.
2. Update README.md for how to set up access key in env.